### PR TITLE
Removing odeqcdr from dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,6 @@ Imports:
     lwgeom (>= 0.2-8),
     magrittr (>= 2.0.1),
     purrr (>= 0.3.4),
-    odeqcdr (>= 0.2.2),
     sf (>= 0.9-6),
     shiny (>= 1.5.0),
     smoothr (>= 0.2.2),


### PR DESCRIPTION
odeqcdr is a dependency for odeqmloctools, and odeqmloctools is a dependency for odeqcdr. This leads to a situation where one cannot install either library, as they each need the other to be previously installed. This change removes odeqcdr as a listed dependenc.